### PR TITLE
画面遷移時のちらつき問題を修正

### DIFF
--- a/src/pages/result.astro
+++ b/src/pages/result.astro
@@ -10,12 +10,21 @@ import { authors } from '../data/authors'
         診断結果
       </h1>
 
-      <div id="resultCard" class="bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-lg p-8 mb-8">
-        <!-- 結果はJavaScriptで動的に挿入 -->
+      <!-- ローディングスピナー -->
+      <div id="loadingSpinner" class="text-center py-8">
+        <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <p class="mt-4 text-gray-600">診断結果を計算中...</p>
       </div>
 
-      <div id="descriptionCard" class="bg-gray-50 rounded-lg p-6 mb-8 text-left">
-        <!-- 説明はJavaScriptで動的に挿入 -->
+      <!-- メインコンテンツ -->
+      <div id="mainContent" class="hidden smooth-transition">
+        <div id="resultCard" class="bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-lg p-8 mb-8">
+          <!-- 結果はJavaScriptで動的に挿入 -->
+        </div>
+
+        <div id="descriptionCard" class="bg-gray-50 rounded-lg p-6 mb-8 text-left">
+          <!-- 説明はJavaScriptで動的に挿入 -->
+        </div>
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
@@ -89,6 +98,16 @@ import { authors } from '../data/authors'
   // 詳細リンクを設定
   const detailLink = document.getElementById('detailLink') as HTMLAnchorElement
   detailLink.href = `/authors/${author.id}`
+
+  // ローディング完了後にコンテンツを表示
+  const loadingSpinner = document.getElementById('loadingSpinner')!
+  const mainContent = document.getElementById('mainContent')!
+  
+  setTimeout(() => {
+    loadingSpinner.classList.add('hidden')
+    mainContent.classList.remove('hidden')
+    mainContent.classList.add('fade-in')
+  }, 300) // 結果計算の演出のため少し長めの遅延
 
   // 診断データをクリア（次回の診断のため）
   clearDiagnosisData()

--- a/src/pages/test2.astro
+++ b/src/pages/test2.astro
@@ -13,20 +13,79 @@ import { questionsSet2a, questionsSet2b } from '../data/questions'
         次の選択肢の中から一つ選んでください。
       </p>
 
-      <form id="test2Form" class="space-y-8">
-        <div id="questionsContainer">
-          <!-- 質問はJavaScriptで動的に挿入 -->
-        </div>
+      <!-- ローディングスピナー -->
+      <div id="loadingSpinner" class="text-center py-8">
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <p class="mt-2 text-gray-600">質問を読み込み中...</p>
+      </div>
 
-        <div class="text-center mt-8">
-          <button
-            type="submit"
-            class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 shadow-md"
-          >
-            次のページへ
-          </button>
-        </div>
-      </form>
+      <!-- メインコンテンツ -->
+      <div id="mainContent" class="hidden smooth-transition">
+        <form id="test2Form" class="space-y-8">
+          <!-- 一般人用質問セット（事前レンダリング） -->
+          <div id="questionsSet2a" class="hidden space-y-8">
+            {questionsSet2a.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- 文豪用質問セット（事前レンダリング） -->
+          <div id="questionsSet2b" class="hidden space-y-8">
+            {questionsSet2b.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div class="text-center mt-8">
+            <button
+              type="submit"
+              class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 shadow-md"
+            >
+              次のページへ
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </Layout>
@@ -48,34 +107,24 @@ import { questionsSet2a, questionsSet2b } from '../data/questions'
   const titleElement = document.querySelector('h1')!
   titleElement.textContent = isGeneral ? '診断ページ 2/3（一般人）' : '診断ページ 2/3（文豪）'
 
-  // 質問を動的に生成
-  const container = document.getElementById('questionsContainer')!
-  questions.forEach((question, index) => {
-    const questionHtml = `
-      <div class="bg-gray-50 rounded-lg p-6">
-        <h2 class="text-lg font-semibold mb-4 text-gray-800">
-          問題${index + 1}: ${question.text}
-        </h2>
-        <div class="space-y-3">
-          ${question.options.map(option => `
-            <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
-              <input
-                type="radio"
-                name="${question.id}"
-                value="${option.value}"
-                required
-                class="mt-1 text-blue-600 focus:ring-blue-500"
-              />
-              <span class="text-gray-700 leading-relaxed">
-                ${option.text}
-              </span>
-            </label>
-          `).join('')}
-        </div>
-      </div>
-    `
-    container.insertAdjacentHTML('beforeend', questionHtml)
-  })
+  // 事前レンダリングされた質問セットの表示/非表示を切り替え
+  const questionsSetA = document.getElementById('questionsSet2a')!
+  const questionsSetB = document.getElementById('questionsSet2b')!
+  const loadingSpinner = document.getElementById('loadingSpinner')!
+  const mainContent = document.getElementById('mainContent')!
+  
+  // ローディング完了後にコンテンツを表示
+  setTimeout(() => {
+    if (isGeneral) {
+      questionsSetA.classList.remove('hidden')
+    } else {
+      questionsSetB.classList.remove('hidden')
+    }
+    
+    loadingSpinner.classList.add('hidden')
+    mainContent.classList.remove('hidden')
+    mainContent.classList.add('fade-in')
+  }, 100) // 最小限の遅延でスムーズな表示
 
   // フォーム送信処理
   const form = document.getElementById('test2Form') as HTMLFormElement
@@ -83,7 +132,10 @@ import { questionsSet2a, questionsSet2b } from '../data/questions'
     e.preventDefault()
     
     const formData = new FormData(form)
-    const score = calculateScore(formData, questions.map(q => q.id))
+    const questionIds = isGeneral 
+      ? questionsSet2a.map(q => q.id)
+      : questionsSet2b.map(q => q.id)
+    const score = calculateScore(formData, questionIds)
     
     saveStageData(2, {
       score,

--- a/src/pages/test3.astro
+++ b/src/pages/test3.astro
@@ -13,20 +13,133 @@ import { questionsSet3aa, questionsSet3ab, questionsSet3ba, questionsSet3bb } fr
         最後の質問です。次の選択肢の中から一つ選んでください。
       </p>
 
-      <form id="test3Form" class="space-y-8">
-        <div id="questionsContainer">
-          <!-- 質問はJavaScriptで動的に挿入 -->
-        </div>
+      <!-- ローディングスピナー -->
+      <div id="loadingSpinner" class="text-center py-8">
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
+        <p class="mt-2 text-gray-600">最終質問を読み込み中...</p>
+      </div>
 
-        <div class="text-center mt-8">
-          <button
-            type="submit"
-            class="bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 shadow-md"
-          >
-            診断結果を見る
-          </button>
-        </div>
-      </form>
+      <!-- メインコンテンツ -->
+      <div id="mainContent" class="hidden smooth-transition">
+        <form id="test3Form" class="space-y-8">
+          <!-- 一般人-高スコア用質問セット -->
+          <div id="questionsSet3aa" class="hidden space-y-8">
+            {questionsSet3aa.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- 一般人-低スコア用質問セット -->
+          <div id="questionsSet3ab" class="hidden space-y-8">
+            {questionsSet3ab.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- 文豪-高スコア用質問セット -->
+          <div id="questionsSet3ba" class="hidden space-y-8">
+            {questionsSet3ba.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <!-- 文豪-低スコア用質問セット -->
+          <div id="questionsSet3bb" class="hidden space-y-8">
+            {questionsSet3bb.map((question, index) => (
+              <div class="bg-gray-50 rounded-lg p-6">
+                <h2 class="text-lg font-semibold mb-4 text-gray-800">
+                  問題{index + 1}: {question.text}
+                </h2>
+                <div class="space-y-3">
+                  {question.options.map((option) => (
+                    <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option.value}
+                        required
+                        class="mt-1 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class="text-gray-700 leading-relaxed">
+                        {option.text}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div class="text-center mt-8">
+            <button
+              type="submit"
+              class="bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 shadow-md"
+            >
+              診断結果を見る
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </Layout>
@@ -46,42 +159,40 @@ import { questionsSet3aa, questionsSet3ab, questionsSet3ba, questionsSet3bb } fr
   const isGeneral = stage2Data!.isGeneral
   const stage2Score = stage2Data!.score
 
-  // 質問セットを決定
+  // 質問セットを決定して表示
+  let activeQuestionSet: string
   let questions
+  
   if (isGeneral) {
-    questions = stage2Score >= 25 ? questionsSet3aa : questionsSet3ab
+    if (stage2Score >= 25) {
+      activeQuestionSet = 'questionsSet3aa'
+      questions = questionsSet3aa
+    } else {
+      activeQuestionSet = 'questionsSet3ab'
+      questions = questionsSet3ab
+    }
   } else {
-    questions = stage2Score >= 15 ? questionsSet3ba : questionsSet3bb
+    if (stage2Score >= 15) {
+      activeQuestionSet = 'questionsSet3ba'
+      questions = questionsSet3ba
+    } else {
+      activeQuestionSet = 'questionsSet3bb'
+      questions = questionsSet3bb
+    }
   }
 
-  // 質問を動的に生成
-  const container = document.getElementById('questionsContainer')!
-  questions.forEach((question, index) => {
-    const questionHtml = `
-      <div class="bg-gray-50 rounded-lg p-6">
-        <h2 class="text-lg font-semibold mb-4 text-gray-800">
-          問題${index + 1}: ${question.text}
-        </h2>
-        <div class="space-y-3">
-          ${question.options.map(option => `
-            <label class="flex items-start space-x-3 cursor-pointer hover:bg-gray-100 p-3 rounded transition duration-200">
-              <input
-                type="radio"
-                name="${question.id}"
-                value="${option.value}"
-                required
-                class="mt-1 text-blue-600 focus:ring-blue-500"
-              />
-              <span class="text-gray-700 leading-relaxed">
-                ${option.text}
-              </span>
-            </label>
-          `).join('')}
-        </div>
-      </div>
-    `
-    container.insertAdjacentHTML('beforeend', questionHtml)
-  })
+  // 事前レンダリングされた質問セットを表示
+  const loadingSpinner = document.getElementById('loadingSpinner')!
+  const mainContent = document.getElementById('mainContent')!
+  const targetQuestionSet = document.getElementById(activeQuestionSet)!
+  
+  // ローディング完了後にコンテンツを表示
+  setTimeout(() => {
+    targetQuestionSet.classList.remove('hidden')
+    loadingSpinner.classList.add('hidden')
+    mainContent.classList.remove('hidden')
+    mainContent.classList.add('fade-in')
+  }, 100)
 
   // フォーム送信処理
   const form = document.getElementById('test3Form') as HTMLFormElement

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,45 @@
 @import "tailwindcss";
+
+/* ページ遷移とローディングのアニメーション */
+.fade-in {
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from { 
+    opacity: 0; 
+    transform: translateY(10px); 
+  }
+  to { 
+    opacity: 1; 
+    transform: translateY(0); 
+  }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* スムーズな表示切り替え */
+.smooth-transition {
+  transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.hidden-smooth {
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+}
+
+.visible-smooth {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- ローディングスピナーによる視覚的フィードバックの追加
- サーバーサイド事前レンダリングで動的コンテンツ生成を最適化  
- CSS fade-inアニメーションによるスムーズな画面遷移を実現

## Test plan
- [ ] test2.astroで一般人/文豪の質問が適切に表示されることを確認
- [ ] test3.astroで4つの質問パターンが正しく表示されることを確認
- [ ] result.astroで診断結果がスムーズに表示されることを確認
- [ ] 各ページでちらつきが解消されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)